### PR TITLE
Add JdbiUnitOfWorkProvider and improve JbdiTransactionsAspect

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -26,11 +26,12 @@
         <surefire.version>2.19.1</surefire.version>
 
         <!--Application-->
-        <dropwizard.jdbi.unitofwork.version>1.0</dropwizard.jdbi.unitofwork.version>
+        <dropwizard.jdbi.unitofwork.version>1.2-SNAPSHOT</dropwizard.jdbi.unitofwork.version>
         <mockito.core.version>3.8.0</mockito.core.version>
         <junit.version>4.13.1</junit.version>
         <jersey.test.framework.version>2.25.1</jersey.test.framework.version>
         <h2.version>2.0.206</h2.version>
+        <google.guice.version>5.0.1</google.guice.version>
     </properties>
 
     <dependencies>
@@ -66,6 +67,13 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.google.inject/guice -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${google.guice.version}</version>
         </dependency>
     </dependencies>
 

--- a/example/src/main/java/com/github/isopropylcyanide/example/app/CountingModule.java
+++ b/example/src/main/java/com/github/isopropylcyanide/example/app/CountingModule.java
@@ -2,11 +2,11 @@ package com.github.isopropylcyanide.example.app;
 
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
 import com.github.isopropylcyanide.jdbiunitofwork.core.LinkedRequestScopedJdbiHandleManager;
-import com.google.common.collect.Sets;
 import com.google.inject.AbstractModule;
+import jersey.repackaged.com.google.common.collect.Lists;
 import org.skife.jdbi.v2.DBI;
 
-import java.util.Set;
+import java.util.List;
 
 public class CountingModule extends AbstractModule {
 
@@ -18,7 +18,7 @@ public class CountingModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        Set<String> daoPackages = Sets.newHashSet("com.github.isopropylcyanide.example.app.dao");
+        List<String> daoPackages = Lists.newArrayList("com.github.isopropylcyanide.example.app.dao");
         JdbiHandleManager handleManager = new LinkedRequestScopedJdbiHandleManager(dbi);
 
         bind(JdbiHandleManager.class).toInstance(handleManager);

--- a/example/src/main/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModule.java
+++ b/example/src/main/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModule.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings({"UnstableApiUsage", "unchecked"})
 public class JdbiUnitOfWorkModule extends AbstractModule {
 
-    private static final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkModule.class);
+    private final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkModule.class);
     private final JdbiHandleManager handleManager;
     private final Set<String> daoPackages;
 

--- a/example/src/main/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModule.java
+++ b/example/src/main/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModule.java
@@ -13,52 +13,29 @@
  */
 package com.github.isopropylcyanide.example.app;
 
+import com.github.isopropylcyanide.jdbiunitofwork.JdbiUnitOfWorkProvider;
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
-import com.github.isopropylcyanide.jdbiunitofwork.core.ManagedHandleInvocationHandler;
-import com.google.common.collect.Sets;
-import com.google.common.reflect.Reflection;
 import com.google.inject.AbstractModule;
-import org.reflections.Reflections;
-import org.reflections.scanners.MethodAnnotationsScanner;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Map;
 
-@SuppressWarnings({"UnstableApiUsage", "unchecked"})
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class JdbiUnitOfWorkModule extends AbstractModule {
 
-    private final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkModule.class);
-    private final JdbiHandleManager handleManager;
-    private final Set<String> daoPackages;
+    private final List<String> daoPackages;
+    private final JdbiUnitOfWorkProvider unitOfWorkProvider;
 
-    public JdbiUnitOfWorkModule(JdbiHandleManager handleManager, Set<String> daoPackages) {
-        this.handleManager = handleManager;
+    public JdbiUnitOfWorkModule(JdbiHandleManager handleManager, List<String> daoPackages) {
         this.daoPackages = daoPackages;
+        this.unitOfWorkProvider = new JdbiUnitOfWorkProvider(handleManager);
     }
 
     @Override
     protected void configure() {
-        Set<? extends Class<?>> allDaoClasses = daoPackages.stream().map(
-                pkg -> Sets.union(
-                        new Reflections(pkg, new MethodAnnotationsScanner()).getMethodsAnnotatedWith(SqlQuery.class),
-                        new Reflections(pkg, new MethodAnnotationsScanner()).getMethodsAnnotatedWith(SqlUpdate.class)
-                ).stream().map(Method::getDeclaringClass).collect(Collectors.toSet())
-        ).flatMap(Collection::stream).collect(Collectors.toSet());
-
-        for (Class klass : allDaoClasses) {
-            log.debug("Binding class [{}] with proxy handler [{}] ", klass.getSimpleName(), handleManager.getClass().getSimpleName());
-            bind(klass).toInstance(createNewProxy(klass, handleManager));
+        Map<? extends Class, Object> instanceProxies = unitOfWorkProvider.getWrappedInstanceForDaoPackage(daoPackages);
+        for (Class klass : instanceProxies.keySet()) {
+            bind(klass).toInstance(instanceProxies.get(klass));
         }
-    }
-
-    private <T> T createNewProxy(Class<T> daoClass, JdbiHandleManager handleManager) {
-        Object proxiedInstance = Reflection.newProxy(daoClass, new ManagedHandleInvocationHandler<>(handleManager, daoClass));
-        return daoClass.cast(proxiedInstance);
     }
 }

--- a/example/src/test/java/com/github/isopropylcyanide/example/app/H2Datasource.java
+++ b/example/src/test/java/com/github/isopropylcyanide/example/app/H2Datasource.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class H2Datasource extends ExternalResource {
 
-    private static final Logger log = LoggerFactory.getLogger(H2Datasource.class);
+    private final Logger log = LoggerFactory.getLogger(H2Datasource.class);
     private DBI dbi;
     private final String createSchemaSqlFile;
     private final String dropSchemaSqlFile;
@@ -56,7 +56,7 @@ public class H2Datasource extends ExternalResource {
 
     private DBI getDBI() {
         final PoolProperties poolConfig = new PoolProperties();
-        poolConfig.setUrl("jdbc:h2:mem:approvalservice;MVCC=true;DEFAULT_LOCK_TIMEOUT=10000;LOCK_MODE=0;DATABASE_TO_UPPER=FALSE");
+        poolConfig.setUrl("jdbc:h2:mem:test;DEFAULT_LOCK_TIMEOUT=10000;LOCK_MODE=0;DATABASE_TO_UPPER=FALSE");
         poolConfig.setDriverClassName("org.h2.Driver");
         poolConfig.setUsername("root");
         poolConfig.setPassword("");

--- a/example/src/test/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModuleTest.java
+++ b/example/src/test/java/com/github/isopropylcyanide/example/app/JdbiUnitOfWorkModuleTest.java
@@ -1,24 +1,21 @@
 package com.github.isopropylcyanide.example.app;
 
+import com.github.isopropylcyanide.example.app.dao.CountingDao;
+import com.github.isopropylcyanide.example.app.resource.CountingResource;
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
-import com.google.common.collect.Sets;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import jersey.repackaged.com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
-import java.util.Set;
+import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-@SuppressWarnings("unused")
 public class JdbiUnitOfWorkModuleTest {
 
     private Injector injector;
@@ -26,31 +23,14 @@ public class JdbiUnitOfWorkModuleTest {
     @Before
     public void setUp() {
         JdbiHandleManager mockHandleManager = mock(JdbiHandleManager.class);
-        when(mockHandleManager.get()).thenReturn(mock(Handle.class));
-        Set<String> daoPackages = Sets.newHashSet("com.github.isopropylcyanide.example.app");
+        List<String> daoPackages = Lists.newArrayList("com.github.isopropylcyanide.example.app");
         JdbiUnitOfWorkModule module = new JdbiUnitOfWorkModule(mockHandleManager, daoPackages);
         injector = Guice.createInjector(module);
     }
 
     @Test
-    public void testModuleBindsTheProxiedDao() {
-        assertNotNull(injector.getInstance(DaoA.class));
-        assertNotNull(injector.getInstance(DaoB.class));
-        assertThrows(ConfigurationException.class, () -> injector.getInstance(DaoC.class));
-    }
-
-    interface DaoA {
-
-        @SqlUpdate
-        void update();
-    }
-
-    interface DaoB {
-
-        @SqlQuery
-        void select();
-    }
-
-    interface DaoC {
+    public void testModuleBindsTheProxiedDaoButFailsForOther() {
+        assertNotNull(injector.getInstance(CountingDao.class));
+        assertThrows(ConfigurationException.class, () -> injector.getInstance(CountingResource.class));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.isopropylcyanide</groupId>
     <artifactId>dropwizard-jdbi-unitofwork</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <name>Dropwizard Jdbi Unit Of Work</name>
     <description>Provides support for Unit Of Work annotations with a Jdbi Backend</description>
     <url>https://github.com/isopropylcyanide/dropwizard-jdbi-unitofwork</url>

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/JdbiUnitOfWorkProvider.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/JdbiUnitOfWorkProvider.java
@@ -1,0 +1,117 @@
+package com.github.isopropylcyanide.jdbiunitofwork;
+
+import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
+import com.github.isopropylcyanide.jdbiunitofwork.core.ManagedHandleInvocationHandler;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.Reflection;
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.skife.jdbi.v2.sqlobject.SqlBatch;
+import org.skife.jdbi.v2.sqlobject.SqlCall;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"UnstableApiUsage", "rawtypes", "unchecked"})
+public class JdbiUnitOfWorkProvider {
+
+    private final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkProvider.class);
+    private final JdbiHandleManager handleManager;
+
+    public JdbiUnitOfWorkProvider(JdbiHandleManager handleManager) {
+        this.handleManager = handleManager;
+    }
+
+    /**
+     * getWrappedInstanceForDaoClass generates a proxy instance of the dao class for which
+     * the jdbi unit of work aspect would be wrapped around with.
+     * <p>
+     * Note: It is recommended to use {@link JdbiUnitOfWorkProvider#getWrappedInstanceForDaoPackage(List)} instead
+     * as passing a list of packages is easier than passing each instance individually.
+     * <p>
+     * This method however may be used in case the classpath scanning is disabled.
+     * If the original class is null or contains no relevant JDBI annotations, this method throws an
+     * exception
+     *
+     * @param daoClass the DAO class for which a proxy needs to be created fo
+     * @return the wrapped instance ready to be passed around
+     */
+    public Object getWrappedInstanceForDaoClass(Class daoClass) {
+        if (daoClass == null) {
+            throw new IllegalArgumentException("DAO Class cannot be null");
+        }
+        boolean atLeastOneJdbiMethod = false;
+        for (Method method : daoClass.getDeclaredMethods()) {
+            if (method.getDeclaringClass() == daoClass) {
+                atLeastOneJdbiMethod = method.getAnnotation(SqlQuery.class) != null;
+                atLeastOneJdbiMethod = atLeastOneJdbiMethod || method.getAnnotation(SqlUpdate.class) != null;
+                atLeastOneJdbiMethod = atLeastOneJdbiMethod || method.getAnnotation(SqlUpdate.class) != null;
+                atLeastOneJdbiMethod = atLeastOneJdbiMethod || method.getAnnotation(SqlBatch.class) != null;
+                atLeastOneJdbiMethod = atLeastOneJdbiMethod || method.getAnnotation(SqlCall.class) != null;
+            }
+        }
+        if (!atLeastOneJdbiMethod) {
+            throw new IllegalArgumentException(String.format("Class [%s] has no method annotated with a Jdbi SQL Object", daoClass.getSimpleName()));
+        }
+
+        log.info("Binding class [{}] with proxy handler [{}] ", daoClass.getSimpleName(), handleManager.getClass().getSimpleName());
+        ManagedHandleInvocationHandler handler = new ManagedHandleInvocationHandler<>(handleManager, daoClass);
+        Object proxiedInstance = Reflection.newProxy(daoClass, handler);
+        return daoClass.cast(proxiedInstance);
+    }
+
+    /**
+     * getWrappedInstanceForDaoPackage generates a map where every DAO class identified
+     * through the given list of packages is mapped to its initialised proxy instance
+     * the jdbi unit of work aspect would be wrapped around with.
+     * <p>
+     * In case classpath scanning is disabled, use {@link JdbiUnitOfWorkProvider#getWrappedInstanceForDaoClass(Class)}
+     * <p>
+     * If the original package list is null, this method throws an exception
+     *
+     * @param daoPackages the list of packages that contain the DAO classes
+     * @return the map mapping dao classes to its initialised proxies
+     */
+    public Map<? extends Class, Object> getWrappedInstanceForDaoPackage(List<String> daoPackages) {
+        if (daoPackages == null) {
+            throw new IllegalArgumentException("DAO Class package list cannot be null");
+        }
+
+        Set<? extends Class<?>> allDaoClasses = daoPackages.stream()
+                .map(this::getDaoClassesForPackage)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        Map<Class, Object> classInstanceMap = new HashMap<>();
+        for (Class klass : allDaoClasses) {
+            log.info("Binding class [{}] with proxy handler [{}] ", klass.getSimpleName(), handleManager.getClass().getSimpleName());
+            Object instance = getWrappedInstanceForDaoClass(klass);
+            classInstanceMap.put(klass, instance);
+        }
+        return classInstanceMap;
+    }
+
+    private Set<? extends Class<?>> getDaoClassesForPackage(String pkg) {
+        MethodAnnotationsScanner scanner = new MethodAnnotationsScanner();
+        Set<Method> daoClasses = new HashSet<>();
+
+        Sets.SetView<Method> union = Sets.union(daoClasses, new Reflections(pkg, scanner).getMethodsAnnotatedWith(SqlQuery.class));
+        union = Sets.union(union, new Reflections(pkg, scanner).getMethodsAnnotatedWith(SqlUpdate.class));
+        union = Sets.union(union, new Reflections(pkg, scanner).getMethodsAnnotatedWith(SqlBatch.class));
+        union = Sets.union(union, new Reflections(pkg, scanner).getMethodsAnnotatedWith(SqlCall.class));
+
+        return union.stream()
+                .map(Method::getDeclaringClass)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/DefaultJdbiHandleManager.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/DefaultJdbiHandleManager.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultJdbiHandleManager implements JdbiHandleManager {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultJdbiHandleManager.class);
+    private final Logger log = LoggerFactory.getLogger(DefaultJdbiHandleManager.class);
     private final DBI dbi;
 
     public DefaultJdbiHandleManager(DBI dbi) {

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/ManagedHandleInvocationHandler.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/ManagedHandleInvocationHandler.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
  */
 public class ManagedHandleInvocationHandler<T> implements InvocationHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(ManagedHandleInvocationHandler.class);
+    private final Logger log = LoggerFactory.getLogger(ManagedHandleInvocationHandler.class);
     private static final Object[] NO_ARGS = {};
     private final JdbiHandleManager handleManager;
     private final Class<T> underlying;

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/RequestScopedJdbiHandleManager.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/core/RequestScopedJdbiHandleManager.java
@@ -29,8 +29,10 @@ import org.slf4j.LoggerFactory;
  */
 public class RequestScopedJdbiHandleManager implements JdbiHandleManager {
 
-    private static final Logger log = LoggerFactory.getLogger(RequestScopedJdbiHandleManager.class);
+    private final Logger log = LoggerFactory.getLogger(RequestScopedJdbiHandleManager.class);
     private final DBI dbi;
+
+    @SuppressWarnings("ThreadLocalUsage")
     private final ThreadLocal<Handle> threadLocal = new ThreadLocal<>();
 
     public RequestScopedJdbiHandleManager(DBI dbi) {

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/HttpGetRequestJdbiUnitOfWorkEventListener.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/HttpGetRequestJdbiUnitOfWorkEventListener.java
@@ -14,7 +14,6 @@
 package com.github.isopropylcyanide.jdbiunitofwork.listener;
 
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
-import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiTransactionAspect;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 import org.slf4j.Logger;
@@ -30,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 class HttpGetRequestJdbiUnitOfWorkEventListener implements RequestEventListener {
 
-    private static final Logger log = LoggerFactory.getLogger(HttpGetRequestJdbiUnitOfWorkEventListener.class);
+    private final Logger log = LoggerFactory.getLogger(HttpGetRequestJdbiUnitOfWorkEventListener.class);
     private final JdbiTransactionAspect transactionAspect;
 
     HttpGetRequestJdbiUnitOfWorkEventListener(JdbiHandleManager handleManager) {
@@ -42,10 +41,7 @@ class HttpGetRequestJdbiUnitOfWorkEventListener implements RequestEventListener 
         RequestEvent.Type type = event.getType();
         log.debug("Handling GET Request Event {} {}", type, Thread.currentThread().getId());
 
-        if (type == RequestEvent.Type.RESOURCE_METHOD_START) {
-            transactionAspect.initHandle();
-
-        } else if (type == RequestEvent.Type.FINISHED) {
+        if (type == RequestEvent.Type.FINISHED) {
             transactionAspect.terminateHandle();
         }
     }

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiTransactionAspect.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiTransactionAspect.java
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.isopropylcyanide.jdbiunitofwork.core;
+package com.github.isopropylcyanide.jdbiunitofwork.listener;
 
+import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
 import org.skife.jdbi.v2.Handle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,20 +27,16 @@ import org.slf4j.LoggerFactory;
  */
 public class JdbiTransactionAspect {
 
-    private static final Logger log = LoggerFactory.getLogger(JdbiTransactionAspect.class);
+    private final Logger log = LoggerFactory.getLogger(JdbiTransactionAspect.class);
     private final JdbiHandleManager handleManager;
-    private Handle handle;
 
     public JdbiTransactionAspect(JdbiHandleManager handleManager) {
         this.handleManager = handleManager;
     }
 
-    public void initHandle() {
-        handle = handleManager.get();
-    }
-
     public void begin() {
         try {
+            Handle handle = handleManager.get();
             handle.begin();
             log.debug("Begin Transaction Thread Id [{}] has handle id [{}] Transaction {} Level {}", Thread.currentThread().getId(), handle.hashCode(), handle.isInTransaction(), handle.getTransactionIsolationLevel());
 
@@ -50,6 +47,7 @@ public class JdbiTransactionAspect {
     }
 
     public void commit() {
+        Handle handle = handleManager.get();
         if (handle == null) {
             log.debug("Handle was found to be null during commit for Thread Id [{}]. It might have already been closed", Thread.currentThread().getId());
             return;
@@ -65,6 +63,7 @@ public class JdbiTransactionAspect {
     }
 
     public void rollback() {
+        Handle handle = handleManager.get();
         if (handle == null) {
             log.debug("Handle was found to be null during rollback for [{}]", Thread.currentThread().getId());
             return;
@@ -78,10 +77,6 @@ public class JdbiTransactionAspect {
     }
 
     public void terminateHandle() {
-        try {
-            handleManager.clear();
-        } finally {
-            handle = null;
-        }
+        handleManager.clear();
     }
 }

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiUnitOfWorkApplicationEventListener.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiUnitOfWorkApplicationEventListener.java
@@ -21,6 +21,7 @@ import org.glassfish.jersey.server.monitoring.RequestEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.HttpMethod;
 import java.util.Set;
 
@@ -41,7 +42,7 @@ import java.util.Set;
  */
 public class JdbiUnitOfWorkApplicationEventListener implements ApplicationEventListener {
 
-    private static final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkApplicationEventListener.class);
+    private  final Logger log = LoggerFactory.getLogger(JdbiUnitOfWorkApplicationEventListener.class);
     private final JdbiHandleManager handleManager;
     private final Set<String> excludedPaths;
 
@@ -56,6 +57,7 @@ public class JdbiUnitOfWorkApplicationEventListener implements ApplicationEventL
     }
 
     @Override
+    @Nullable
     public RequestEventListener onRequest(RequestEvent event) {
         String path = event.getUriInfo().getPath();
         if (excludedPaths.stream().anyMatch(path::contains)) {

--- a/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/NonHttpGetRequestJdbiUnitOfWorkEventListener.java
+++ b/src/main/java/com/github/isopropylcyanide/jdbiunitofwork/listener/NonHttpGetRequestJdbiUnitOfWorkEventListener.java
@@ -15,7 +15,6 @@ package com.github.isopropylcyanide.jdbiunitofwork.listener;
 
 import com.github.isopropylcyanide.jdbiunitofwork.JdbiUnitOfWork;
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
-import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiTransactionAspect;
 import org.glassfish.jersey.server.model.ResourceMethod;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
@@ -34,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 class NonHttpGetRequestJdbiUnitOfWorkEventListener implements RequestEventListener {
 
-    private static final Logger log = LoggerFactory.getLogger(NonHttpGetRequestJdbiUnitOfWorkEventListener.class);
+    private final Logger log = LoggerFactory.getLogger(NonHttpGetRequestJdbiUnitOfWorkEventListener.class);
     private final JdbiTransactionAspect transactionAspect;
 
     NonHttpGetRequestJdbiUnitOfWorkEventListener(JdbiHandleManager handleManager) {
@@ -76,7 +75,6 @@ class NonHttpGetRequestJdbiUnitOfWorkEventListener implements RequestEventListen
     }
 
     private void initialise(boolean isTransactional) {
-        transactionAspect.initHandle();
         if (isTransactional) {
             transactionAspect.begin();
         }

--- a/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/JdbiUnitOfWorkProviderTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/JdbiUnitOfWorkProviderTest.java
@@ -1,0 +1,75 @@
+package com.github.isopropylcyanide.jdbiunitofwork;
+
+import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class JdbiUnitOfWorkProviderTest {
+
+    @Mock
+    private JdbiHandleManager handleManager;
+
+    private JdbiUnitOfWorkProvider provider;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.provider = new JdbiUnitOfWorkProvider(handleManager);
+    }
+
+    @Test
+    public void testGetWrappedInstanceForNullDaoClassThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> provider.getWrappedInstanceForDaoClass(null));
+    }
+
+    @Test
+    public void testGetWrappedInstanceForDaoClass() {
+        assertNotNull(provider.getWrappedInstanceForDaoClass(DaoA.class));
+        assertNotNull(provider.getWrappedInstanceForDaoClass(DaoB.class));
+        assertThrows(IllegalArgumentException.class, () -> provider.getWrappedInstanceForDaoClass(DaoC.class));
+    }
+
+    @Test
+    public void testGetWrappedInstanceForNullDaoPackageThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> provider.getWrappedInstanceForDaoPackage(null));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void testGetWrappedInstanceForDaoPackage() {
+        Map<? extends Class, Object> instanceObjectMap = provider.getWrappedInstanceForDaoPackage(Lists.newArrayList(
+                "com.github.isopropylcyanide.jdbiunitofwork"
+        ));
+        assertEquals(2, instanceObjectMap.size());
+        assertNotNull(instanceObjectMap.get(DaoA.class));
+        assertNotNull(instanceObjectMap.get(DaoB.class));
+        assertNull(instanceObjectMap.get(DaoC.class));
+    }
+
+    interface DaoA {
+
+        @SqlUpdate
+        void update();
+    }
+
+    interface DaoB {
+
+        @SqlQuery
+        void select();
+    }
+
+    interface DaoC {
+    }
+}

--- a/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/HttpGetRequestJdbiUnitOfWorkEventListenerTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/HttpGetRequestJdbiUnitOfWorkEventListenerTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.skife.jdbi.v2.Handle;
 
 import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.FINISHED;
-import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.RESOURCE_METHOD_START;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,17 +29,8 @@ public class HttpGetRequestJdbiUnitOfWorkEventListenerTest {
     }
 
     @Test
-    public void testHandleIsInitialisedWhenEventTypeIsResourceMethodStart() {
-        when(requestEvent.getType()).thenReturn(RESOURCE_METHOD_START);
-        listener.onEvent(requestEvent);
-        verify(handleManager, times(1)).get();
-    }
-
-    @Test
     public void testHandleIsClosedWhenEventTypeIsFinished() {
-        when(requestEvent.getType()).thenReturn(RESOURCE_METHOD_START).thenReturn(FINISHED);
-        listener.onEvent(requestEvent);
-        verify(handleManager, times(1)).get();
+        when(requestEvent.getType()).thenReturn(FINISHED);
 
         listener.onEvent(requestEvent);
         verify(handleManager, times(1)).clear();

--- a/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiTransactionAspectTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/JdbiTransactionAspectTest.java
@@ -1,5 +1,6 @@
-package com.github.isopropylcyanide.jdbiunitofwork.core;
+package com.github.isopropylcyanide.jdbiunitofwork.listener;
 
+import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.skife.jdbi.v2.Handle;
@@ -29,16 +30,7 @@ public class JdbiTransactionAspectTest {
     }
 
     @Test
-    public void testInitHandleWorksAsExpected() {
-        aspect.initHandle();
-
-        verify(handleManager, times(1)).get();
-    }
-
-    @Test
     public void testBeginWhenHandleBeginThrowsException() {
-        aspect.initHandle();
-
         when(mockHandle.begin()).thenThrow(IllegalArgumentException.class);
         assertThrows(IllegalArgumentException.class, () -> aspect.begin());
         verify(handleManager, times(1)).clear();
@@ -47,8 +39,6 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testBeginWorksAsExpected() {
-        aspect.initHandle();
-
         doReturn(mockHandle).when(mockHandle).begin();
         aspect.begin();
 
@@ -67,8 +57,6 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testCommitWhenHandleCommitThrowsException() {
-        aspect.initHandle();
-
         when(mockHandle.commit()).thenThrow(IllegalArgumentException.class);
         assertThrows(IllegalArgumentException.class, () -> aspect.commit());
         verify(mockHandle, times(1)).rollback();
@@ -76,8 +64,6 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testCommitWorksAsExpected() {
-        aspect.initHandle();
-
         doReturn(mockHandle).when(mockHandle).commit();
         aspect.commit();
 
@@ -94,8 +80,6 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testRollbackWhenHandleRollbackThrowsException() {
-        aspect.initHandle();
-
         when(mockHandle.rollback()).thenThrow(IllegalArgumentException.class);
         assertThrows(IllegalArgumentException.class, () -> aspect.rollback());
         verify(mockHandle, times(1)).rollback();
@@ -103,8 +87,6 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testRollbackWorksAsExpected() {
-        aspect.initHandle();
-
         doReturn(mockHandle).when(mockHandle).rollback();
         aspect.rollback();
 
@@ -121,9 +103,7 @@ public class JdbiTransactionAspectTest {
 
     @Test
     public void testTerminateHandleWorksAsExpected() {
-        aspect.initHandle();
         aspect.terminateHandle();
-
         verify(handleManager, times(1)).clear();
     }
 }

--- a/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/NonHttpGetRequestJdbiUnitOfWorkEventListenerTest.java
+++ b/src/test/java/com/github/isopropylcyanide/jdbiunitofwork/listener/NonHttpGetRequestJdbiUnitOfWorkEventListenerTest.java
@@ -1,7 +1,5 @@
 package com.github.isopropylcyanide.jdbiunitofwork.listener;
 
-import javax.ws.rs.core.MediaType;
-
 import com.github.isopropylcyanide.jdbiunitofwork.JdbiUnitOfWork;
 import com.github.isopropylcyanide.jdbiunitofwork.core.JdbiHandleManager;
 import org.glassfish.jersey.server.model.Resource;
@@ -12,6 +10,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.skife.jdbi.v2.Handle;
 
+import javax.ws.rs.core.MediaType;
+
 import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.FINISHED;
 import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.ON_EXCEPTION;
 import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.RESOURCE_METHOD_START;
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class NonHttpGetRequestJdbiUnitOfWorkEventListenerTest {
@@ -43,12 +44,12 @@ public class NonHttpGetRequestJdbiUnitOfWorkEventListenerTest {
     }
 
     @Test
-    public void testHandleIsInitialisedWhenEventTypeIsResourceMethodStartButNotTransactional() {
+    public void testHandleIsNoOpWhenEventTypeIsResourceMethodStartButNotTransactional() {
         when(requestEvent.getType()).thenReturn(RESOURCE_METHOD_START);
         when(requestEvent.getUriInfo().getMatchedResourceMethod()).thenReturn(null);
 
         listener.onEvent(requestEvent);
-        verify(handleManager, times(1)).get();
+        verifyNoInteractions(handleManager);
     }
 
     @Test
@@ -75,7 +76,6 @@ public class NonHttpGetRequestJdbiUnitOfWorkEventListenerTest {
         when(requestEvent.getUriInfo().getMatchedResourceMethod()).thenReturn(null);
 
         listener.onEvent(requestEvent);
-        verify(handleManager, times(1)).get();
 
         listener.onEvent(requestEvent);
         verify(handleManager, times(1)).clear();
@@ -83,10 +83,7 @@ public class NonHttpGetRequestJdbiUnitOfWorkEventListenerTest {
 
     @Test
     public void testHandleIsClosedWhenEventTypeIsFinished() {
-        when(requestEvent.getType()).thenReturn(RESOURCE_METHOD_START).thenReturn(FINISHED);
-        listener.onEvent(requestEvent);
-        verify(handleManager, times(1)).get();
-
+        when(requestEvent.getType()).thenReturn(FINISHED);
         listener.onEvent(requestEvent);
         verify(handleManager, times(1)).clear();
     }


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Enhancement | Medium |

## Description
- Add `JdbiUnitOfWorkProvider` making it easy for teams to specify DAO classes or direct packages without having to deal with proxy creation themselves.
- Rewrite `example` to use the `JdbiUnitOfWorkProvider` and update `jdbi-unit-of-work` version in `example`
- Remove dependency on `StringUtils`
- Make logger non static
- Remove call sites for explicit `initHandle`. This should be implicit, whenever somebody needs a handle, `handleManager` would be invoked. Also, removing all instances of `handle` directly. All communication via `handleManager`

